### PR TITLE
Currency Endpoint Improvements

### DIFF
--- a/Helper/CurrencyFormatHelper.php
+++ b/Helper/CurrencyFormatHelper.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace NoFraud\Checkout\Helper;
+
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Locale\CurrencyInterface;
+
+class CurrencyFormatHelper extends AbstractHelper
+{
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * @var CurrencyInterface
+     */
+    protected $localeCurrency;
+
+    public function __construct(
+        Context $context,
+        StoreManagerInterface $storeManager,
+        CurrencyInterface $localeCurrency
+    ) {
+        parent::__construct($context);
+        $this->storeManager = $storeManager;
+        $this->localeCurrency = $localeCurrency;
+    }
+
+    /**
+     * Determines the currency symbol position for a given currency code.
+     *
+     * @param string $currencyCode The currency code.
+     * @return string 'Standard' or 'Right' indicating the symbol position.
+     */
+    public function getCurrencySymbolPosition($currencyCode)
+    {
+        $currency = $this->localeCurrency->getCurrency($currencyCode);
+        $formatted = $currency->toCurrency(0);
+        if (strpos($formatted, $currency->getSymbol()) <= strpos($formatted, '0')) {
+            return 'STANDARD';
+        } else {
+            return 'RIGHT';
+        }
+    }
+}


### PR DESCRIPTION
On this PR, we tackled the issue where fetching currency info hinged on a shaky method of snagging the currency symbol's placement directly from a protected class attribute. Here's what's new:

- Rolled out a fresh helper class, powered by Magento\Framework\Locale\CurrencyInterface, ensuring our currency formatting is now keenly aware of locale nuances. This move aligns our approach neatly with Magento 2's design ethos.
- Crafted a nifty method to nail down the currency symbol's rightful spot via a deep dive into formatting details. This tweak guarantees our fix is not just sturdy but also smartly adjusts to the formatting whims of various locales, making it universally solid.