### PR TITLE
Reset Cart Endpoint

### DIFF
--- a/Api/CartManagementInterface.php
+++ b/Api/CartManagementInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace NoFraud\Checkout\Api;
+
+interface CartManagementInterface
+{
+    /**
+     * @param int $cartId
+     * @return bool
+     */
+    public function removeAddresses($cartId);
+}

--- a/Model/CartManagement.php
+++ b/Model/CartManagement.php
@@ -1,0 +1,102 @@
+<?php
+namespace NoFraud\Checkout\Model;
+
+use NoFraud\Checkout\Api\CartManagementInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Api\Data\AddressInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+class CartManagement implements CartManagementInterface
+{
+    protected $cartRepository;
+
+    public function __construct(
+        CartRepositoryInterface $cartRepository
+    ) {
+        $this->cartRepository = $cartRepository;
+    }
+
+    public function removeAddresses($cartId)
+    {
+        $quote = $this->cartRepository->getActive($cartId);
+
+        // Attempt to reset the shipping address
+        try {
+            if ($quote->getShippingAddress()->getId()) {
+                $shippingAddress = $quote->getShippingAddress();
+                $this->resetAddress($shippingAddress);
+                $quote->setShippingAddress($shippingAddress);
+            }
+
+            if ($quote->getBillingAddress()->getId()) {
+                $billingAddress = $quote->getBillingAddress();
+                $this->resetAddress($billingAddress);
+                $quote->setBillingAddress($billingAddress);
+            }
+            $quote->collectTotals();
+           $this->cartRepository->save($quote);
+
+        } catch (\Exception $e) {
+            throw new LocalizedException(__('Unable to remove addresses: %1', $e->getMessage()));
+        }
+
+        return true;
+    }
+
+    private function resetAddress(AddressInterface $address)
+    {
+        // Resetting provided fields to null or default values. Some fields like 'country_id' require a valid default othervise it fail to store.
+        $address->setStreet(['N/A']) // Street expects an array
+        ->setCity('N/A') // Magento's internal logic prevents from setting to null
+        ->setRegion('N/A') // Magento's internal logic prevents from setting to null
+        ->setRegionId(null)
+        ->setPostcode('000000') // Magento's internal logic prevents from setting to null
+        ->setCountryId('US') // Magento's internal logic prevents from setting to null
+        ->setCompany('N/A') // Magento's internal logic prevents from setting to null
+        ->setFax('N/A') // Magento's internal logic prevents from setting to null
+        ->setSaveInAddressBook(0)
+        ->setPrefix(null)
+        ->setVatId(null)
+        ->setSameAsBilling(1)
+        ->setCollectShippingRates(0)
+        ->setShippingDescription('N/A') // Magento's internal logic prevents from setting to null
+        ->setWeight(0)
+        ->setSubtotalWithDiscount(0.0000)
+        ->setBaseSubtotalWithDiscount(0.0000)
+        ->setTaxAmount(0.0000)
+        ->setBaseTaxAmount(0.0000)
+        ->setShippingAmount(0.0000)
+        ->setBaseShippingAmount(0.0000)
+        ->setShippingTaxAmount(0.0000)
+        ->setBaseShippingTaxAmount(0.0000)
+        ->setDiscountAmount(0.0000)
+        ->setBaseDiscountAmount(0.0000)
+        ->setGrandTotal($address->getSubtotal())
+        ->setBaseGrandTotal($address->getBaseSubtotal())
+        ->setCustomerNotes(null)
+        ->setAppliedTaxes([])
+        ->setDiscountDescription(null)
+        ->setShippingDiscountAmount(0.0000)
+        ->setBaseShippingDiscountAmount(0.0000)
+        ->setSubtotalInclTax(0.0000)
+        ->setBaseSubtotalTotalInclTax(0.0000)
+        ->setDiscountTaxCompensationAmount(0.0000)
+        ->setBaseDiscountTaxCompensationAmount(0.0000)
+        ->setShippingDiscountTaxCompensationAmount(0.0000)
+        ->setBaseShippingDiscountTaxCompensationAmount(0.0000)
+        ->setShippingInclTax(0.0000)
+        ->setBaseShippingInclTax(0.0000)
+        // Additional settings for VAT and shipping related fields
+        ->setVatIsValid(null)
+        ->setVatRequestId(null)
+        ->setVatRequestDate(null)
+        ->setVatRequestSuccess(null)
+        ->setValidatedCountryCode(null)
+        ->setValidatedVatNumber(null)
+        ->setGiftMessageId(null)
+        ->setFreeShipping(0) // Assuming this should be reset as well
+        ->setShippingMethod('N/A'); // Magento's internal logic prevents from setting to null
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -11,10 +11,11 @@
 	<preference for="NoFraud\Checkout\Api\GiftCardAccountManagementInterface" type="NoFraud\Checkout\Model\GiftCardAccountManagement"/>
 	<preference for="NoFraud\Checkout\Api\CurrencyInformationInterface" type="NoFraud\Checkout\Model\CurrencyInformation"/>
 	<preference for="NoFraud\Checkout\Api\PhonenumberInterface" type="NoFraud\Checkout\Model\PhonenumberData" />
-	<preference for="NoFraud\Checkout\Api\CustomerInformationInterface" type="NoFraud\Checkout\Model\CustomerInformation"/>	
+	<preference for="NoFraud\Checkout\Api\CustomerInformationInterface" type="NoFraud\Checkout\Model\CustomerInformation"/>
 	<preference for="Magento\Payment\Model\Checks\ZeroTotal" type="NoFraud\Checkout\Model\Checks\ZeroTotal" />
 	<preference for="NoFraud\Checkout\Api\StoreCreditManagementInterface" type="NoFraud\Checkout\Model\StoreCreditManagement"/>
 	<preference for="NoFraud\Checkout\Api\FacebookPixelInterface" type="NoFraud\Checkout\Model\FacebookPixelCheckoutEvent"/>
+	<preference for="NoFraud\Checkout\Api\CartManagementInterface" type="NoFraud\Checkout\Model\CartManagement"/>
 	<preference for="Route\Route\Helper\Data" type="NoFraud\Checkout\Helper\RouteData" />
 	<type name="Magento\Quote\Api\CartRepositoryInterface">
 		<plugin name="GiftCardQuoteExtension" type="NoFraud\Checkout\Plugin\Quote\CartRepositoryPlugin" />

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -12,10 +12,16 @@
 			<resource ref="Magento_Sales::sales" />
 		</resources>
 	</route>
+	<route url="/V1/nofraudcheckout/:cartId/remove-addresses" method="POST">
+		<service class="NoFraud\Checkout\Api\CartManagementInterface" method="removeAddresses" />
+		<resources>
+			<resource ref="self"/>
+		</resources>
+	</route>
 	<route url="/V1/nofraudcheckout/initialize" method="POST">
 		<service class="NoFraud\Checkout\Api\SetConfiguration" method="enableConfiguration" />
 		<resources>
-			<resource ref="NoFraud_Checkout::config"/>	
+			<resource ref="NoFraud_Checkout::config"/>
 		</resources>
 	</route>
 	<route url="/V1/nofraudcheckout/validate" method="POST">


### PR DESCRIPTION
### Objective
The primary goal of this development is to introduce a "Reset Cart" endpoint. This endpoint will allow for the removal of shipping methods, shipping addresses, and billing addresses associated with a given Cart ID, while ensuring the Cart remains linked to it's customer.

### Implementation Details

- Endpoint Name: V1/nofraudcheckout/:cart_id/remove-addresses
- Method: POST
- Input: Cart ID (Quote ID)
- Functionality:
    - The endpoint will validate the provided Cart ID to ensure it corresponds to an existing cart.
    - Once validated, the endpoint will proceed to remove any existing shipping methods, shipping addresses, and billing addresses associated with the cart.
    - The removal process is designed to ensure that the cart's linkage to a customer_id (if any) remains unaffected.
    - After successfully resetting the cart's details, the endpoint will return true indicating the cart has been reset.
    
   
